### PR TITLE
upgrade janusgraph to 0.6.2

### DIFF
--- a/documents/janusgraph_connection_test.md
+++ b/documents/janusgraph_connection_test.md
@@ -1,0 +1,38 @@
+# JanusGraph connection test
+
+This file describes how to check locally this service can properly connect JanusGraph.
+
+## Keycloak Setup
+
+See [how_to_upload_csv_locally.md#Keycloak Setup section](how_to_upload_csv_locally.md).
+
+## JanusGraph Setup
+```shell
+# clone the discovery service if you didn't yet
+git clone git@github.com:ubirch/ubirch-discovery-service.git
+
+# go the discovery service
+cd ubirch-discovery-service
+
+# run JanusGraph
+sh src/test/resources/embedded-jg/janusgraph-0.6.2/bin/janusgraph-server.sh console ../custom-gremlin-conf.yaml start
+
+# go to the console of JanusGraph
+sh src/test/resources/embedded-jg/janusgraph-0.6.2/bin/gremlin.sh
+
+# inside of the JanusGraph console
+gremlin> :rem connect tinkerpop.server ../custom-remote.yaml session
+```
+
+## Call device endpoints
+
+```shell
+# run the service
+mvn exec:java -Dexec.mainClass=com.ubirch.webui.Boot
+
+token=`curl -s -d "client_id=admin-cli" -d "username=chrisx" -d "password=password" -d "grant_type=password" "http://localhost:8080/auth/realms/test-realm/protocol/openid-connect/token" | jq -r .access_token`
+# curl -X POST -v -H "Content-Type: application/json" -H "authorization: bearer $token" http://localhost:8081/ubirch-web-ui/api/v1/devices/state/:from/:to  -d ':deviceIds'
+# devices should be owned by the user(In the example, the user is chrisx)
+# the device should belong to OWN_DEVICES_chrisx
+curl -X POST -v -H "Content-Type: application/json" -H "authorization: bearer $token" http://localhost:8081/ubirch-web-ui/api/v1/devices/state/2022-10-01/2022-11-05 -d '42956ef1-307e-49c8-995c-9b5b757828cd,3b3da0c2-e97e-4832-9bcb-29e886aeb5a6'
+```

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,9 @@
         <keycloack.version>15.1.1</keycloack.version>
         <resteasy.version>3.6.3.Final</resteasy.version>
         <ubirch-kafka-express.version>1.2.11-SNAPSHOT</ubirch-kafka-express.version>
-
+        <com.fasterxml.jackson.core.jackson-databind.version>2.13.4.2</com.fasterxml.jackson.core.jackson-databind.version>
+        <com.fasterxml.jackson.core.jackson-core.version>2.13.4</com.fasterxml.jackson.core.jackson-core.version>
+        <org.bouncycastle.version>1.70</org.bouncycastle.version>
         <build.number>${timestamp}-dev</build.number>
 
         <!-- plugins -->
@@ -108,7 +110,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.70</version>
+            <version>${org.bouncycastle.version}</version>
         </dependency>
         <!-- Bouncy Castle Crypto Lib -->
 
@@ -219,7 +221,14 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.8</version>
+            <version>${com.fasterxml.jackson.core.jackson-databind.version}</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${com.fasterxml.jackson.core.jackson-core.version}</version>
         </dependency>
 
         <!-- /Logging -->
@@ -378,7 +387,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.64</version>
+            <version>${org.bouncycastle.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -75,10 +75,9 @@
         <ubirch-crypto.version>2.1.0</ubirch-crypto.version>
         <jose4j.version>0.6.5</jose4j.version>
 
-        <gremlinScala.version>3.5.1.4</gremlinScala.version>
-        <janusGraph.version>0.6.1</janusGraph.version>
+        <gremlinScala.version>3.5.3.2</gremlinScala.version>
+        <janusGraph.version>0.6.2</janusGraph.version>
         <tinkerPopDriver.version>3.5.1</tinkerPopDriver.version>
-        <tinkerPopJava.version>2.6.0</tinkerPopJava.version>
         <testcontainers.version>1.15.2</testcontainers.version>
 
         <jetty-servlets.version>9.4.45.v20220203</jetty-servlets.version>
@@ -109,7 +108,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.64</version>
+            <version>1.70</version>
         </dependency>
         <!-- Bouncy Castle Crypto Lib -->
 
@@ -324,12 +323,6 @@
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>gremlin-driver</artifactId>
             <version>${tinkerPopDriver.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.tinkerpop.gremlin</groupId>
-            <artifactId>gremlin-java</artifactId>
-            <version>${tinkerPopJava.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -75,9 +75,9 @@
         <ubirch-crypto.version>2.1.0</ubirch-crypto.version>
         <jose4j.version>0.6.5</jose4j.version>
 
-        <gremlinScala.version>3.4.7.2</gremlinScala.version>
-        <janusGraph.version>0.5.2</janusGraph.version>
-        <tinkerPopDriver.version>3.3.3</tinkerPopDriver.version>
+        <gremlinScala.version>3.5.1.4</gremlinScala.version>
+        <janusGraph.version>0.6.1</janusGraph.version>
+        <tinkerPopDriver.version>3.5.1</tinkerPopDriver.version>
         <tinkerPopJava.version>2.6.0</tinkerPopJava.version>
         <testcontainers.version>1.15.2</testcontainers.version>
 

--- a/src/main/resources/application.base.conf
+++ b/src/main/resources/application.base.conf
@@ -33,7 +33,7 @@ janus {
   connector {
 
     hosts = 127.0.0.1
-    port = 8282
+    port = 8182
 
     connectionPool {
       reconnectInterval = 500

--- a/src/main/resources/application.base.conf
+++ b/src/main/resources/application.base.conf
@@ -40,7 +40,6 @@ janus {
       maxWaitForConnection = 6000
     }
     serializer {
-      className = org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0
       config {
         ioRegistries = [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry]
       }

--- a/src/main/scala/com/ubirch/webui/models/graph/DefaultGraphClient.scala
+++ b/src/main/scala/com/ubirch/webui/models/graph/DefaultGraphClient.scala
@@ -46,7 +46,6 @@ class DefaultGraphClient(gc: GremlinConnector) extends GraphClient with LazyLogg
   def getLastHashes(hwDeviceId: String, n: Int): Future[List[LastHash]] = {
 
     logger.debug(s"LastHash: Looking for last hashes of $hwDeviceId")
-
     val futureMaybeLastHash = gc.g
       .V()
       .has(Key[String]("device_id"), hwDeviceId)

--- a/src/main/scala/com/ubirch/webui/services/connector/janusgraph/GremlinConnectorFactory.scala
+++ b/src/main/scala/com/ubirch/webui/services/connector/janusgraph/GremlinConnectorFactory.scala
@@ -3,7 +3,7 @@ package com.ubirch.webui.services.connector.janusgraph
 import com.typesafe.config.Config
 import com.ubirch.webui.services.connector.janusgraph.ConnectorType.ConnectorType
 import org.apache.tinkerpop.gremlin.driver.Cluster
-import org.apache.tinkerpop.gremlin.driver.ser.GraphBinaryMessageSerializerV1
+import org.apache.tinkerpop.gremlin.driver.ser.{ GraphBinaryMessageSerializerV1, Serializers }
 
 import java.util
 
@@ -37,7 +37,7 @@ object GremlinConnectorFactory {
 
     val conf = new util.HashMap[String, AnyRef]()
     conf.put("ioRegistries", config.getAnyRef("janus.connector.serializer.config.ioRegistries").asInstanceOf[java.util.ArrayList[String]])
-    val serializer = new GraphBinaryMessageSerializerV1()
+    val serializer = Serializers.GRAPHBINARY_V1D0.simpleInstance()
     serializer.configure(conf, null)
 
     cluster.serializer(serializer).create()

--- a/src/main/scala/com/ubirch/webui/services/connector/janusgraph/GremlinConnectorFactory.scala
+++ b/src/main/scala/com/ubirch/webui/services/connector/janusgraph/GremlinConnectorFactory.scala
@@ -3,7 +3,7 @@ package com.ubirch.webui.services.connector.janusgraph
 import com.typesafe.config.Config
 import com.ubirch.webui.services.connector.janusgraph.ConnectorType.ConnectorType
 import org.apache.tinkerpop.gremlin.driver.Cluster
-import org.apache.tinkerpop.gremlin.driver.ser.{ GraphBinaryMessageSerializerV1, Serializers }
+import org.apache.tinkerpop.gremlin.driver.ser.Serializers
 
 import java.util
 

--- a/src/main/scala/com/ubirch/webui/services/connector/janusgraph/GremlinConnectorFactory.scala
+++ b/src/main/scala/com/ubirch/webui/services/connector/janusgraph/GremlinConnectorFactory.scala
@@ -2,7 +2,10 @@ package com.ubirch.webui.services.connector.janusgraph
 
 import com.typesafe.config.Config
 import com.ubirch.webui.services.connector.janusgraph.ConnectorType.ConnectorType
-import org.apache.commons.configuration.PropertiesConfiguration
+import org.apache.tinkerpop.gremlin.driver.Cluster
+import org.apache.tinkerpop.gremlin.driver.ser.GraphBinaryMessageSerializerV1
+
+import java.util
 
 object GremlinConnectorFactory {
 
@@ -16,17 +19,27 @@ object GremlinConnectorFactory {
     }
   }
 
-  def buildProperties(config: Config): PropertiesConfiguration = {
-    val conf = new PropertiesConfiguration()
-    conf.addProperty("hosts", config.getString("janus.connector.hosts"))
-    conf.addProperty("port", config.getString("janus.connector.port"))
-    conf.addProperty("serializer.className", config.getString("janus.connector.serializer.className"))
-    conf.addProperty("connectionPool.maxWaitForConnection", config.getString("janus.connector.connectionPool.maxWaitForConnection"))
-    conf.addProperty("connectionPool.reconnectInterval", config.getString("janus.connector.connectionPool.reconnectInterval"))
-    // no idea why the following line needs to be duplicated. Doesn't work without
-    // cf https://stackoverflow.com/questions/45673861/how-can-i-remotely-connect-to-a-janusgraph-server first answer, second comment ¯\_ツ_/¯
-    conf.addProperty("serializer.config.ioRegistries", config.getAnyRef("janus.connector.serializer.config.ioRegistries").asInstanceOf[java.util.ArrayList[String]])
-    conf.addProperty("serializer.config.ioRegistries", config.getStringList("janus.connector.serializer.config.ioRegistries"))
-    conf
+  def buildCluster(config: Config): Cluster = {
+    val cluster = Cluster.build()
+    val hosts: List[String] = config.getString("janus.connector.hosts")
+      .split(",")
+      .toList
+      .map(_.trim)
+      .filter(_.nonEmpty)
+
+    cluster.addContactPoints(hosts: _*)
+      .port(config.getInt("janus.connector.port"))
+    val maxWaitForConnection = config.getInt("janus.connector.connectionPool.maxWaitForConnection")
+    if (maxWaitForConnection > 0) cluster.maxWaitForConnection(maxWaitForConnection)
+
+    val reconnectInterval = config.getInt("janus.connector.connectionPool.reconnectInterval")
+    if (reconnectInterval > 0) cluster.reconnectInterval(reconnectInterval)
+
+    val conf = new util.HashMap[String, AnyRef]()
+    conf.put("ioRegistries", config.getAnyRef("janus.connector.serializer.config.ioRegistries").asInstanceOf[java.util.ArrayList[String]])
+    val serializer = new GraphBinaryMessageSerializerV1()
+    serializer.configure(conf, null)
+
+    cluster.serializer(serializer).create()
   }
 }

--- a/src/main/scala/com/ubirch/webui/services/connector/janusgraph/JanusGraphConnector.scala
+++ b/src/main/scala/com/ubirch/webui/services/connector/janusgraph/JanusGraphConnector.scala
@@ -16,7 +16,7 @@ import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph
   */
 protected class JanusGraphConnector extends GremlinConnector with LazyLogging with ConfigBase {
 
-  val cluster: Cluster = Cluster.open(GremlinConnectorFactory.buildProperties(conf))
+  val cluster: Cluster = GremlinConnectorFactory.buildCluster(conf)
 
   implicit val graph: ScalaGraph = EmptyGraph.instance.asScala.configure(_.withRemote(DriverRemoteConnection.using(cluster)))
   val g: TraversalSource = graph.traversal

--- a/src/test/resources/application.test.conf
+++ b/src/test/resources/application.test.conf
@@ -38,7 +38,6 @@ janus {
       maxWaitForConnection = 6000
     }
     serializer {
-      className = org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0
       config {
         ioRegistries = [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry]
       }


### PR DESCRIPTION
- upgrade janusgraph from 0.5.3 to 0.6.2
- check if this service can connect to JanusGraph locally via the `device/state` endpoint

**Needs to be merged when JanusGraph on dev becomes v0.6.2**